### PR TITLE
Fix getting started guidelines after the change of directories

### DIFF
--- a/docs/getting-started/machines/raspberrypi.md
+++ b/docs/getting-started/machines/raspberrypi.md
@@ -27,10 +27,12 @@ Follow the steps below to copy the image to microSD card and to boot it on Raspb
 * Output Image location in build machine for Raspberry Pi 2: *tmp/deploy/images/raspberrypi2/agl-demo-platform-raspberrypi2.rpi-sdimg*
 * Output Image location in build machine for Raspberry Pi 3: *tmp/deploy/images/raspberrypi3/agl-demo-platform-raspberrypi3.rpi-sdimg*
 * Unmount the microSD card and after that flash output image to it card with root user:
+
 ```
 sudo umount [sdcard device]
 sudo dd if=[output image] of=[sdcard device] bs=4M
 sync
 ```
+
 * Plug your microSD card into Raspberry Pi 2 or 3 and boot the board
 

--- a/doctools/generate-getting-started.sh
+++ b/doctools/generate-getting-started.sh
@@ -65,9 +65,13 @@ case $DOCTYPE in
 		;;
 	html)
 		DOCTYPE=html
+		EXPORTTEMPLATES=$EXPORTDIR/$DOCTYPE/templates
 		mkdir -p $EXPORTDIR/$DOCTYPE/
 		cp -R $DOCDIR/images $EXPORTDIR/$DOCTYPE/
-		FILECONFIG="-f markdown -t html -s -S --toc -c $TOOLDIR/templates/html/pandoc.css -B $TOOLDIR/templates/html/header.html -A $TOOLDIR/templates/html/footer.html"
+		# Delete the old and copy the latest templates
+		rm -rf $EXPORTTEMPLATES
+		cp -R $TOOLDIR/templates/html  $EXPORTTEMPLATES
+		FILECONFIG="-f markdown -t html -s -S --toc -c templates/pandoc.css -B $EXPORTTEMPLATES/header.html -A $EXPORTTEMPLATES/footer.html"
 		;;
 	*)
 		echo "Unknown doctype '$DOCTYPE'." >&2

--- a/doctools/generate-getting-started.sh
+++ b/doctools/generate-getting-started.sh
@@ -56,6 +56,8 @@ case $DOCTYPE in
 	pdf)
 		DOCTYPE=pdf
 		mkdir -p $EXPORTDIR/$DOCTYPE/
+		# Go to the docs directory to have accsss to images
+		cd $DOCDIR
 		FILECONFIG="-N --template=$TOOLDIR/templates/pdf/agl.tex --variable mainfont=\"Arial\" --variable sansfont=\"Arial\" --variable monofont=\"Arial\" --variable fontsize=12pt --latex-engine=xelatex --toc"
 		;;
 	dokuwiki|wiki)

--- a/doctools/templates/html/header.html
+++ b/doctools/templates/html/header.html
@@ -1,4 +1,4 @@
 <div id="header">
-	<p><a href="https://www.automotivelinux.org/"><img src="../templates/html/images/agl-logo.png" alt="Automotive Grade Linux" /></a></p>
+	<p><a href="https://www.automotivelinux.org/"><img src="templates/images/agl-logo.png" alt="Automotive Grade Linux" /></a></p>
 </div>
 


### PR DESCRIPTION
Hi,

Recently the directory structure of docs-agl has been changed and as a side effect the generate-getting-started.sh has not properly generating HTML headers and images in PDF files. This GitHub pull request brings the necessary changes to fix the script. 

Furthermore there is fix for the in the markdown  format for Raspberry Pi and now pandoc also successfully exports valid DokuWiki format for this machine.

Best regards, Leon