### PR TITLE
porter-footer.md: Debbuging

### DIFF
--- a/docs/getting-started/footers/porter-footer.md
+++ b/docs/getting-started/footers/porter-footer.md
@@ -13,7 +13,17 @@ locking=true
 #panel-location=none
 
 [output]
-#name=Virtual-1
 name=HDMI-A-1
 mode=1024x768
+#mode=1920x1080
+#mode=173.00  1920 2048 2248 2576  1080 1083 1088 1120 -hsync +vsync
 ```
+
+# Debugging
+
+It is possible to debug AGL images on Renesas Porter board using USB to Mini-B USB cable. Plug the USB connector of the cable to your computer and use your favorite tool for serial communication. For example on Ubuntu and other Linux distributions you may use screen:
+
+```
+sudo screen /dev/ttyUSB0 38400
+```
+

--- a/docs/getting-started/machines/porter.md
+++ b/docs/getting-started/machines/porter.md
@@ -125,7 +125,7 @@ Written by John Gilmore and Jay Fenlason.
 
 ```
 sudo tar --extract --numeric-owner --preserve-permissions --preserve-order --totals \
-           --directory=/tmp/agl --file=agl-demo-platform-porter.tar.bz2
+           --xattrs-include='*' --directory=/tmp/agl --file=agl-demo-platform-porter.tar.bz2
 ```
 
 * Copy Kernel Image and Device Tree Blob file into the **boot** directory:


### PR DESCRIPTION
Add instructions for connecting USB to Micro-B USB
cable to Renesas Porter board for serial
debugging.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>