### PR TITLE
Fix: wrong R-Car Gen3 drivers files names

### DIFF
--- a/docs/getting-started/machines/R-Car-Starter-Kit-gen3.md
+++ b/docs/getting-started/machines/R-Car-Starter-Kit-gen3.md
@@ -38,8 +38,8 @@ Here after is an example of the typical files downloaded at the time of writing:
 chmod a+r $XDG_DOWNLOAD_DIR/*.zip
 ls -l $XDG_DOWNLOAD_DIR
 total 8220
--rw-r--r-- 1 XXX XXX    4619114 14 sept. 05:02 R-Car_Gen3_Series_Evaluation_Software_Package_for_Linux-20160906.tar.gz
--rw-r--r-- 1 XXX XXX    4619796 10 oct.  23:23 R-Car_Gen3_Series_Evaluation_Software_Package_for_Linux-20160906.zip
+-rw-r--r--. 1 1664 agl-sdk 4.5M Dec  8 15:23 R-Car_Gen3_Series_Evaluation_Software_Package_for_Linux-20160906.zip
+-rw-r--r--. 1 1664 agl-sdk 2.5M Dec  8 15:24 R-Car_Gen3_Series_Evaluation_Software_Package_of_Linux_Drivers-20160906.zip
 ```
 
 ## Setting up the build environment:


### PR DESCRIPTION
Change-Id: I1ef6c2574aaf08918b526ba882ef637965831d43
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>