### PR TITLE
Update Raspberry Pi docs and fix format to export valid docuwiki for AGL wiki

### DIFF
--- a/README.getting-started.md
+++ b/README.getting-started.md
@@ -20,3 +20,11 @@ Execute the following command to export a markdown file with instructions for Ra
 ```
 ./doctools/generate-getting-started.sh -m raspberrypi -d html
 ```
+
+# Export Docuwiki
+
+Execute the following command to export a markdown file with instructions for Raspberry Pi to docuwiki syntaxt which is used in the AGL wiki:
+
+```
+./doctools/generate-getting-started.sh -m raspberrypi -d wiki
+```

--- a/docs/getting-started/footers/raspberrypi-footer.md
+++ b/docs/getting-started/footers/raspberrypi-footer.md
@@ -53,4 +53,4 @@ It is possible to debug AGL images on Raspberry Pi using 3.3V USB to serial cabl
 sudo screen /dev/ttyUSB0 115200
 ```
 
-Pay attention that the colours of the cable may vary depending on the vendor. If you have USB console cable from Adafruit please have a look [here](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-5-using-a-console-cable/connect-the-lead).
+Pay attention that the colors of the cable may vary depending on the vendor. If you have USB console cable from Adafruit please have a look [here](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-5-using-a-console-cable/connect-the-lead).

--- a/docs/getting-started/machines/raspberrypi.md
+++ b/docs/getting-started/machines/raspberrypi.md
@@ -28,6 +28,8 @@ Follow the steps below to copy the image to microSD card and to boot it on Raspb
 * Output Image location in build machine for Raspberry Pi 3: *tmp/deploy/images/raspberrypi3/agl-demo-platform-raspberrypi3.rpi-sdimg*
 * Unmount the microSD card and after that flash output image to it card with root user:
 
+*Note: the sdimage files can also be named rpi-sdimg-ota in case you have the **"agl-sota"** feature enabled*
+
 ```
 sudo umount [sdcard device]
 sudo dd if=[output image] of=[sdcard device] bs=4M

--- a/docs/getting-started/source-code.md
+++ b/docs/getting-started/source-code.md
@@ -148,7 +148,7 @@ cd $AGL_TOP
 source meta-agl/scripts/aglsetup.sh -h
 ```
 
-Once you run aglsetup.sh with your desired paramaters, you can build any target desired.
+Once you run aglsetup.sh with your desired parameters, you can build any target desired.
 
 ## Features supported by aglsetup
 

--- a/docs/getting-started/source-code.md
+++ b/docs/getting-started/source-code.md
@@ -1,7 +1,9 @@
 
 
 # Introduction: Building target AGL image with Yocto project
+
 The standard Yocto process is made of the following steps:
+
 * Setting up your operating system.
 * Setting up the build environment for R-Car BSP.
 * Downloading the proprietary drivers and installing them in the build environment (if needed).
@@ -20,6 +22,7 @@ If you want to bypass the build phase and quick boot the board, you can download
 The very first step is to ensure that your system can run the build system of the Yocto Project.
 
 **Important**: it only runs on Linux
+
  * if your system is Windows© or iOS© you should use a virtualization solution  (Virtualbox, VMWare ...) to run a Linux VM on your system.
 
 For AGL 2.1, Yocto Project 2.1, known as krogoth, has been selected for the BSP and build system.  
@@ -29,6 +32,7 @@ Reference data for configuring your system can be found in the Yocto documentati
 
 
 Here after an extract of this documentation for most common Linux distributions:
+
 * The build system should be able to run on any modern distributions that has the following versions for:
     * Python
     * Git 1.7.8 or greater

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Extended attributes MUST be copied
 
-***IMPORTANT, The extended attribute set during image construction MUST be copied to the SD card.***
+**IMPORTANT, The extended attribute set during image construction MUST be copied to the SD card.**
 
 When using tar to create the SDcard, it is a common error to not copy the extended attributes. Find below instruction for using tar.
 
@@ -49,22 +49,31 @@ TARGET_CXXFLAGS_remove_pn-gcc-runtime = "-D_GLIBCXX_USE_CXX11_ABI=0" CXXFLAGS_re
 
 To disable IVI-Shell and revert to the "plain old" weston desktop, you can follow the 4 steps below:
 
-1. modify */etc/xdg/weston/weston.ini* and comment the line mentioning IVI-shell. For example on Porter board:
+* Modify */etc/xdg/weston/weston.ini* and comment the line mentioning IVI-shell. For example on Porter board:
 
+```
            [core]
            backend=drm-backend.so
            #shell=ivi-shell.so
            ...
-2. modify */usr/lib/systemd/user/afm-user-daemon.service* and comment the line specifying QT Wayland backend:
+```
 
+* modify */usr/lib/systemd/user/afm-user-daemon.service* and comment the line specifying QT Wayland backend:
+
+```
            ...
            #Environment=QT_WAYLAND_SHELL_INTEGRATION=ivi-shell
            ...
-3. disable Homescreen services:
+```
 
+* disable Homescreen services:
+
+```
            # systemctl disable HomeScreenAppFrameworkBinderAGL.service
            # systemctl disable HomeScreen.service
            # systemctl disable InputEventManager.service
            # systemctl disable WindowManager.service
-4. Reboot your target and you should then be able to start apps on the standard weston screen using afm-util
+```
+
+* Reboot your target and you should then be able to start apps on the standard weston screen using afm-util
 


### PR DESCRIPTION
Hi,

Upon a request from the mailing list I decide to update the article for building AGL for Raspberry Pi in AGL. I used again pandoc to generate docuwiki syntax and after that to copy & paste it in AGL wiki. During the process I had to do the following updates and modifications:
* Fixed the formatting to ensure that the output document is fine,
* Modified to the specific instructions for Raspberry Pi,
* Fixed a minor  typo,
* Added an example how to export docuwiki documents to the README.

Best regards,
Leon