### PR TITLE
index.html: Qt not QT

### DIFF
--- a/webdocs-agl/site/index.html
+++ b/webdocs-agl/site/index.html
@@ -15,7 +15,7 @@ change_frequency: monthly
             <div class="col-xs-12 col-sm-7 hero_content">
 				<!-- <img class="hero_logo hidden-xs" src="{{ site.baseurl }}{{ site.logo.textonly }}"/> -->
                 <!-- <img class="hero_logo visible-xs" src="{{ site.baseurl }}/static/img/logo_full_2.svg" /> -->
-                <p>Automotive Apps with <em>HTML5</em>, <em>QT</em> <em>OpenGL</em></p>
+                <p>Automotive Apps with <em>HTML5</em>, <em>Qt</em> <em>OpenGL</em></p>
                 <p>Multiple platforms on <em>a common code base</em></p>
                 <p>Free and <em>open source</em></p>
                 <div class="hero_buttons">


### PR DESCRIPTION
The application framework should be written as Qt
(capital Q and lowercase t). It is not written as
QT (capital Q, capital T) because QT refers to
Apple QuickTime and a lot of other things.

Bug-AGL: SPEC-721

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>