### PR TITLE
R-Car-Starter-Kit-gen3.md: Switch from xz to bz2

### DIFF
--- a/docs/getting-started/machines/R-Car-Starter-Kit-gen3.md
+++ b/docs/getting-started/machines/R-Car-Starter-Kit-gen3.md
@@ -287,8 +287,8 @@ tar (GNU tar) 1.28
 Copy Automotive Grade Linux (AGL) files onto the mircoSD card by extracting the root file system archive:
 
 ```bash
-sudo $TAR --extract --xz --numeric-owner --preserve-permissions --preserve-order --totals \
-           --xattrs-include='*' --directory=$SDCARD --file=agl-demo-platform-h3ulcb.tar.xz
+sudo $TAR --extract -j --numeric-owner --preserve-permissions --preserve-order --totals \
+           --xattrs-include='*' --directory=$SDCARD --file=agl-demo-platform-h3ulcb.tar.bz2
 ```
 
 Copy Kernel Image and Device Tree Blob file into the **boot** directory:


### PR DESCRIPTION
Update the documentation following the switch of
the archives produced by bitbake from xz to bz2.

Bug-AGL: SPEC-786

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>