### PR TITLE
qemu.md: Update instructions slighly for DRM

### DIFF
--- a/docs/getting-started/machines/qemu.md
+++ b/docs/getting-started/machines/qemu.md
@@ -60,7 +60,7 @@ Boot the **agl-demo-platform-qemux86-64.vmdk** image in qemu with kvm support:
 qemu-system-x86_64 -enable-kvm -m 2048 \
 	-hda agl-demo-platform-qemux86-64.vmdk \
 	-cpu kvm64 -cpu qemu64,+ssse3,+sse4.1,+sse4.2,+popcnt \
-	-vga std -show-cursor \
+	-vga virtio -show-cursor \
 	-device virtio-rng-pci \
 	-serial mon:stdio -serial null \
 	-soundhw hda \
@@ -72,7 +72,7 @@ qemu-system-x86_64 -enable-kvm -m 2048 \
 
 #### Install
 
-Download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+Download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) 5.2.0 or later.
 
 #### Boot
 


### PR DESCRIPTION
Starting with Eel we must have a video driver that supports DRM.  For
QEMU, this can be done with std or virtio.  For best results moving
forward, we should use virtio here.  For VirtualBox we must use version
5.2.0 or later.  There is nothing additional required for VMWare.

Bug-AGL: SPEC-776

Signed-off-by: Tom Rini <trini@konsulko.com>