### PR TITLE
Updated MAC Kernel configuration [SPEC-1453]

### DIFF
--- a/docs/security-blueprint/annexes/ConfigNotes.md
+++ b/docs/security-blueprint/annexes/ConfigNotes.md
@@ -98,9 +98,16 @@ Boot-Consoles-MemDump-7 | `mdc`          | _Disabled_
 Boot-Consoles-MemDump-8 | `mtest`        | _Disabled_
 Boot-Consoles-MemDump-9 | `loopw`        | _Disabled_
 
-Domain               | Object | Recommendations
--------------------- | ------ | ------------------------------------------
-Kernel-General-MAC-1 | SMACK  | Must implement a Mandatory Access Control.
+Domain               | `Config` name  | `Value`
+-------------------- | -------------- | --------------------------------------
+Kernel-General-MAC-1 | CONFIG_IP_NF_SECURITY   | m
+Kernel-General-MAC-2 | CONFIG_IP6_NF_SECURITY  | m
+Kernel-General-MAC-3 | CONFIG_EXT2_FS_SECURITY | y
+Kernel-General-MAC-4 | CONFIG_EXT3_FS_SECURITY | y
+Kernel-General-MAC-5 | CONFIG_EXT4_FS_SECURITY | y
+Kernel-General-MAC-6 | CONFIG_SECURITY         | y
+Kernel-General-MAC-7 | CONFIG_SECURITY_SMACK   | y
+Kernel-General-MAC-8 | CONFIG_TMPFS_XATTR      | y
 
 Domain                 | `Config` name  | `Value`
 ---------------------- | -------------- | -------
@@ -158,6 +165,10 @@ Domain                            | `compiler` and `linker` options | _State_
 Kernel-General-OverwriteAttacks-1 | `-z,relro`                      | _Enable_
 Kernel-General-OverwriteAttacks-2 | `-z,now`                        | _Enable_
 
+Domain                          | Object          | Recommendations
+------------------------------- | --------------- | --------------------------------
+Kernel-General-LibraryLinking-1 | Dynamic linking | Should generally not be allowed.
+
 Domain                         | `Config` name    | `Value`
 ------------------------------ | ---------------- | -------
 Kernel-Memory-RestrictAccess-1 | `CONFIG_DEVKMEM` | `n`
@@ -178,7 +189,6 @@ Kernel-Memory-LoadAllSymbols-2 | `CONFIG_KALLSYMS_ALL` | `n`
 Domain                | `Config` name              | `Value`
 --------------------- | -------------------------- | -------
 Kernel-Memory-Stack-1 | `CONFIG_CC_STACKPROTECTOR` | `y`
-Other defenses include things like shadow stacks.
 
 Domain                 | `Config` name   | `Value`
 ---------------------- | --------------- | -------
@@ -471,9 +481,5 @@ Application-Cloud-Infrastructure-5 | App integrity | Applications must be signed
 Domain                        | Object                                    | Recommendations
 ----------------------------- | ----------------------------------------- | ---------------------------------
 Application-Cloud-Transport-1 | Integrity, confidentiality and legitimacy | Should implement IPSec standards.
-
-Domain        | Object                                    | Recommendations
-------------- | ----------------------------------------- | ---------------
-Update-FOTA-1 | Integrity, confidentiality and legitimacy | Must be secure.
 
 <!-- end-section-config -->

--- a/docs/security-blueprint/annexes/todoNotes.md
+++ b/docs/security-blueprint/annexes/todoNotes.md
@@ -17,10 +17,6 @@ Domain                | Improvement
 --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Hypervisor-Abstract-1 | Complete Hypervisor part ([jailhouse](https://github.com/siemens/jailhouse) / [KVM](https://www.linux-kvm.org/page/Main_Page) / [Xen](https://www.xenproject.org/developers/teams/embedded-and-automotive.html)).
 
-Domain       | Improvement
------------- | ----------------
-Kernel-MAC-1 | Add MAC config note.
-
 Domain                           | Improvement
 -------------------------------- | -----------------------------
 Kernel-General-IndependentExec-1 | Kernel or/and platform part ?

--- a/docs/security-blueprint/part-4/1-General.md
+++ b/docs/security-blueprint/part-4/1-General.md
@@ -6,19 +6,22 @@ Kernel should controls access with labels and policy.
 
 <!-- section-config -->
 
-Domain               | Object | Recommendations
--------------------- | ------ | ------------------------------------------
-Kernel-General-MAC-1 | SMACK  | Must implement a Mandatory Access Control.
+Domain               | `Config` name  | `Value`
+-------------------- | -------------- | --------------------------------------
+Kernel-General-MAC-1 | CONFIG_IP_NF_SECURITY   | m
+Kernel-General-MAC-2 | CONFIG_IP6_NF_SECURITY  | m
+Kernel-General-MAC-3 | CONFIG_EXT2_FS_SECURITY | y
+Kernel-General-MAC-4 | CONFIG_EXT3_FS_SECURITY | y
+Kernel-General-MAC-5 | CONFIG_EXT4_FS_SECURITY | y
+Kernel-General-MAC-6 | CONFIG_SECURITY         | y
+Kernel-General-MAC-7 | CONFIG_SECURITY_SMACK   | y
+Kernel-General-MAC-8 | CONFIG_TMPFS_XATTR      | y
 
 <!-- end-section-config -->
 
-<!-- section-todo -->
-
-Domain       | Improvement
------------- | ----------------
-Kernel-MAC-1 | Add MAC config note.
-
-<!-- end-section-todo -->
+Please also refer to the [**Mandatory Access Control** documentation in Platform](../part-5/1-MAC.html) part.
+You can also find useful documentation and links on wikipedia about [**MAC**](https://en.wikipedia.org/wiki/Mandatory_access_control)
+and about [**SMACK**](https://en.wikipedia.org/wiki/Simplified_Mandatory_Access_Control_Kernel).
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
- added Kernel configs to enable MAC / SMACK support.
- added links to refer MAC in Platform part and other useful  externals links.

Signed-off-by: Sebastien Douheret <sebastien.douheret@iot.bzh>