### PR TITLE
host-configuration + candevstudio: install natively AGL microservices…

### DIFF
--- a/webdocs-agl/content/tocs/apis_services/fetched_files.yml
+++ b/webdocs-agl/content/tocs/apis_services/fetched_files.yml
@@ -153,6 +153,20 @@ repositories:
         - source: pictures/Global_Signaling_Architecture.png
         - source: pictures/iotbzh_logo_small.png
 -
+    url_fetch: "GITHUB_FETCH"
+    git_name: iotbzh/agl-documentation
+    git_commit: "master"
+    documents:
+        - source: candevstudio/docs/1_Usage.md
+        - source: candevstudio/docs/2_can_device_socketcan_backend.md
+        - source: candevstudio/docs/3_Add_CAN_Device.md
+        - source: candevstudio/docs/4_Configure_CanRawSender_Node.md
+        - source: candevstudio/docs/5_Using_CanRawView.md
+        - source: candevstudio/docs/pictures/CANdevStudio.png
+        - source: candevstudio/docs/pictures/canrawsender.png
+        - source: candevstudio/docs/pictures/canrawviewer.png
+
+-
     url_fetch: AGL_GITHUB_FETCH
     url_edit: AGL_GITHUB_EDIT
     git_name: "%project_source%/docs-agl"

--- a/webdocs-agl/content/tocs/apis_services/toc_dev_en.yml
+++ b/webdocs-agl/content/tocs/apis_services/toc_dev_en.yml
@@ -84,6 +84,18 @@ children:
           url: reference/iotbzh2016/signaling/AGL-Message-Signaling-Developer-Guidelines.pdf
         - name: CAN Signaling Benchmark
           url: reference/iotbzh2016/signaling/AGL-AppFW-CAN-Signaling-Benchmark.pdf
+        - name: CanDevStudio Quickstart
+          children:
+                - name: Usage Guide
+                  url: reference/candevstudio/docs/1_Usage.html
+                - name: Bringing up a CAN device using socketcan backend
+                  url: reference/candevstudio/docs/2_can_device_socketcan_backend.html
+                - name: Add a CAN device in CANdevStudio
+                  url: reference/candevstudio/docs/3_Add_CAN_Device.html
+                - name: Configure a CanRawSender node
+                  url: reference/candevstudio/docs/4_Configure_CanRawSender_Node.html
+                - name: Using CanRawView
+                  url: reference/candevstudio/docs/5_Using_CanRawView.html
         - url: reference/signaling/resources.html
 -
     name: Audio Framework

--- a/webdocs-agl/content/tocs/devguides/fetched_files.yml
+++ b/webdocs-agl/content/tocs/devguides/fetched_files.yml
@@ -71,6 +71,16 @@ repositories:
     git_name: iotbzh/agl-documentation
     git_commit: "master"
     documents:
+        - source: host-configuration/docs/0_Abstract.md
+        - source: host-configuration/docs/1_Prerequisites.md
+        - source: host-configuration/docs/2_AGL_Application_Framework.md
+        - source: host-configuration/docs/3_AGL_XDS.md
+        - source: host-configuration/docs/4_Candevstudio.md
+-
+    url_fetch: "GITHUB_FETCH"
+    git_name: iotbzh/agl-documentation
+    git_commit: "master"
+    documents:
         - source: sdk-devkit/docs/part-1/1_0_Abstract.md
         - source: sdk-devkit/docs/part-1/1_1-Deploy_image.md
         - source: sdk-devkit/docs/part-1/1_2-Setting-up-your_os.md

--- a/webdocs-agl/content/tocs/devguides/toc_dev_en.yml
+++ b/webdocs-agl/content/tocs/devguides/toc_dev_en.yml
@@ -46,6 +46,24 @@ children:
         - url: reference/meta-agl-demo.html
         - url: reference/meta-agl-devel.html
 -
+    name: Host Configuration
+    children:
+        -
+            name: Abstract
+            url: reference/host-configuration/docs/0_Abstract.html
+        -
+            name: Prerequisites
+            url: reference/host-configuration/docs/1_Prerequisites.html
+        -
+            name: AGL Application Framework
+            url: reference/host-configuration/docs/2_AGL_Application_Framework.html
+        -
+            name: AGL XDS
+            url: reference/host-configuration/docs/3_AGL_XDS.html
+        -
+            name: CanDevStudio
+            url: reference/host-configuration/docs/4_Candevstudio.html
+-
     name: "Development Kit: build AGL image"
     children:
         -


### PR DESCRIPTION
… and quickstart for candevstudio

host-configuration: The purpose of this section is to help developers to
natively develop and debug AGL microservices. Thanks to OBS, packages for
debian/ubuntu, openSUSE and fedora distributions are available and can be
installed on developer host.

candevstudio: Development tool for CAN bus simulation.

Signed-off-by: Clément Bénier <clement.benier@iot.bzh>