### PR TITLE
Fix : wrong path to pages due to new remote page.

### DIFF
--- a/webdocs-agl/content/tocs/devguides/fetched_files.yml
+++ b/webdocs-agl/content/tocs/devguides/fetched_files.yml
@@ -74,8 +74,9 @@ repositories:
         - source: host-configuration/docs/0_Abstract.md
         - source: host-configuration/docs/1_Prerequisites.md
         - source: host-configuration/docs/2_AGL_Application_Framework.md
-        - source: host-configuration/docs/3_AGL_XDS.md
-        - source: host-configuration/docs/4_Candevstudio.md
+        - source: host-configuration/docs/3_Binding_Build_Example.md
+        - source: host-configuration/docs/4_AGL_XDS.md
+        - source: host-configuration/docs/5_Candevstudio.md
 -
     url_fetch: "GITHUB_FETCH"
     git_name: iotbzh/agl-documentation

--- a/webdocs-agl/content/tocs/devguides/toc_dev_en.yml
+++ b/webdocs-agl/content/tocs/devguides/toc_dev_en.yml
@@ -58,11 +58,14 @@ children:
             name: AGL Application Framework
             url: reference/host-configuration/docs/2_AGL_Application_Framework.html
         -
+            name: Binding Build Example
+            url: reference/host-configuration/docs/3_Binding_Build_Example.html
+        -
             name: AGL XDS
-            url: reference/host-configuration/docs/3_AGL_XDS.html
+            url: reference/host-configuration/docs/4_AGL_XDS.html
         -
             name: CanDevStudio
-            url: reference/host-configuration/docs/4_Candevstudio.html
+            url: reference/host-configuration/docs/5_Candevstudio.html
 -
     name: "Development Kit: build AGL image"
     children:


### PR DESCRIPTION
The insertion of a new page in a remote documentation broke paths here,
breaking chapters of the website (docs.automotivelinux.org).

Signed-off-by: 8000ff <clementmallejac@gmail.com>