### PR TITLE
Update doc about cmake AFB templates module

### DIFF
--- a/webdocs-agl/content/tocs/devguides/fetched_files.yml
+++ b/webdocs-agl/content/tocs/devguides/fetched_files.yml
@@ -119,12 +119,17 @@ repositories:
         - source: sdk-devkit/docs/part-2/pictures/xming_server.png
 -
     url_fetch: "GERRIT_FETCH"
-    git_name: apps/app-templates
+    git_name: src/cmake-apps-module
     git_commit: "master"
-    dst_prefix: sdk-devkit/docs/part-2
+    src_prefix: "docs/dev_guide"
+    dst_prefix: "cmakeafbtemplates"
     documents:
-        - source: README.md
-          destination: 2_4-Use-app-templates.md
+        - source: 0_Abstract.md
+        - source: 1_Quickstart.md
+        - source: 2_project_architecture.md
+        - source: 3_advanced_usage.md
+        - source: 4_advanced_customization.md
+        - source: 5_autobuild.md
 -
     url_fetch: "GERRIT_FETCH"
     git_name: src/xds/xds-docs

--- a/webdocs-agl/content/tocs/devguides/toc_dev_en.yml
+++ b/webdocs-agl/content/tocs/devguides/toc_dev_en.yml
@@ -99,9 +99,27 @@ children:
         -
             name: Developing with container
             url: reference/sdk-devkit/docs/part-2/2_3-Dev-with-container.html
+-
+    name: "Usage of CMake Afb Template module"
+    children:
         -
-            name: Use CMake templates to develop an app
-            url: reference/sdk-devkit/docs/part-2/2_4-Use-app-templates.html
+            name: "Abstract"
+            url: "reference/cmakeafbtemplates/0_Abstract.html"
+        -
+            name: "Quickstart"
+            url: "reference/cmakeafbtemplates/1_Quickstart.html"
+        -
+            name: "Project architecture"
+            url: "reference/cmakeafbtemplates/2_project_architecture.html"
+        -
+            name: "Advanced usage"
+            url: "reference/cmakeafbtemplates/3_advanced_usage.html"
+        -
+            name: "Advanced customization"
+            url: "reference/cmakeafbtemplates/4_advanced_customization.html"
+        -
+            name: "The autobuild script"
+            url: "reference/cmakeafbtemplates/5_autobuild.html"
 -
     name: "X(cross) Development System: User's Guide"
     children:


### PR DESCRIPTION
This work separates the documentation section about usage of the CMakeAfbTemplates
module to make it more visible and clearer

Change-Id: I9eb49770af143f164b002a6352860b98a5d9ac5b
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>