### PR TITLE
Fix low-can repository source

### DIFF
--- a/webdocs-agl/content/tocs/apis_services/fetched_files.yml
+++ b/webdocs-agl/content/tocs/apis_services/fetched_files.yml
@@ -127,7 +127,7 @@ repositories:
         - source: pictures/triskel_iot_bzh.svg
 
 -
-    git_name : apps/low-level-can-service
+    git_name : apps/agl-service-can-low-level
     git_commit: master
     src_prefix : docs
     dst_prefix: signaling


### PR DESCRIPTION
Old repository pointed by the fetcher, now fixed.

Change-Id: I354fad906ec2442d5ba761286c3d6d50a6cb5da1
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>